### PR TITLE
Add PostgreSQL 12 support

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,7 @@
     "pg": "^7.14.0",
     "reflect-metadata": "^0.1.13",
     "striptags": "^3.1.1",
-    "typeorm": "^0.2.20"
+    "typeorm": "^0.2.21"
   },
   "devDependencies": {
     "@types/cors": "^2.8.6",


### PR DESCRIPTION
Typeorm fixed a bug with support for PostgreSQL 12 in version 0.2.21, this PR upgrades the Typeorm dependency. See: https://github.com/typeorm/typeorm/issues/4573