### PR TITLE
Add `editor.rulers` VSCode rule to match with prettier `printWidth` in `.prettierrc` config file.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.rulers": [100],
   "eslint.workingDirectories": [
     {
       "directory": "./client",


### PR DESCRIPTION
I just added VSCode ruler settings based on prettier config in `settings.json` file in `.vscode` directory. So that if user's global VSCode configuration ruler is some thing smaller than 100, the code statements don't look like ugly. BTW thanks for this nice repository 🙏 