### PR TITLE
Fixed the event of Button to be passed to the onClick function

### DIFF
--- a/client/src/shared/components/Button/index.jsx
+++ b/client/src/shared/components/Button/index.jsx
@@ -30,16 +30,16 @@ const defaultProps = {
 
 const Button = forwardRef(
   ({ children, variant, icon, iconSize, disabled, isWorking, onClick, ...buttonProps }, ref) => {
-    const handleClick = () => {
+    const handleClick = (e) => {
       if (!disabled && !isWorking) {
-        onClick();
+        onClick(e);
       }
     };
 
     return (
       <StyledButton
         {...buttonProps}
-        onClick={handleClick}
+        onClick={(e)=> handleClick(e)}
         variant={variant}
         disabled={disabled || isWorking}
         isWorking={isWorking}


### PR DESCRIPTION
Hi, first, thanks for the simplified and well-separated boilerplate.

Since I couldn't use the common module event methods like e.preventDefault() and e.stopPropagation() for the Button, I modified the source to make it work.