### PR TITLE
webpack 4가 Node.js v17+의 OpenSSL 3.0과 호환되지 않는 문제를 --openssl-legacy-pr…

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,11 +4,11 @@
   "author": "Ivor Reic",
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider webpack-dev-server",
     "start:production": "pm2 start --name 'jira_client' server.js",
     "test:jest": "jest",
     "test:cypress": "node_modules/.bin/cypress open",
-    "build": "rm -rf build && webpack --config webpack.config.production.js --progress",
+    "build": "rm -rf build && NODE_OPTIONS=--openssl-legacy-provider webpack --config webpack.config.production.js --progress",
     "pre-commit": "lint-staged"
   },
   "devDependencies": {


### PR DESCRIPTION
…ovider 플래그 추가로 해결